### PR TITLE
Drum grid skeleton: 3×32 sequencer

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
         <!-- Core workspace: sequencer canvas (left) and constraint controls (right) -->
         <div class="content-row">
           <div id="sequencerGrid" class="sequencer-grid" role="region" aria-live="polite">
-            <p>Step grid placeholder: rhythm lanes and steps will appear here.</p>
+            <div id="stepSequencer" class="step-sequencer" aria-label="Step sequencer"></div>
           </div>
 
           <!-- Constraint panel used for controlled rhythm-editing tasks -->

--- a/script.js
+++ b/script.js
@@ -30,6 +30,139 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
+  // Basic sequencer scaffold (visual editing only; no playback timing yet).
+  const sequencerMount = document.getElementById("stepSequencer");
+  const instruments = [
+    { name: "Kick" },
+    { name: "Snare" },
+    { name: "Hi-hat" },
+  ];
+  const stepsPerInstrument = 32;
+  const pattern = Array.from({ length: instruments.length }, () =>
+    Array(stepsPerInstrument).fill(false)
+  );
+
+  if (sequencerMount) {
+    const instrumentButtons = [];
+
+    // Mark the end of each 8-step block for visual grouping only.
+    function isBlockEnd(stepIndex) {
+      return (stepIndex + 1) % 8 === 0 && stepIndex !== stepsPerInstrument - 1;
+    }
+
+    function symbolMarkup(name) {
+      if (name === "Kick") {
+        return `
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="12" cy="12" r="7"></circle>
+            <circle cx="12" cy="12" r="2.3"></circle>
+          </svg>
+        `;
+      }
+
+      if (name === "Snare") {
+        return `
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <ellipse cx="12" cy="8.5" rx="6.4" ry="2.2"></ellipse>
+            <path d="M5.6 8.5v6.2"></path>
+            <path d="M18.4 8.5v6.2"></path>
+            <path d="M5.6 14.7h12.8"></path>
+          </svg>
+        `;
+      }
+
+      return `
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <ellipse cx="12" cy="11.5" rx="7.2" ry="2.1"></ellipse>
+          <path d="M12 13.6v5.2"></path>
+          <path d="M8.3 18.8h7.4"></path>
+        </svg>
+      `;
+    }
+
+    // Highlight one instrument row at a time (visual selection only).
+    function setActiveInstrument(index) {
+      instrumentButtons.forEach((button, buttonIndex) => {
+        const isActive = buttonIndex === index;
+        button.classList.toggle("instrument--active", isActive);
+        button.setAttribute("aria-pressed", String(isActive));
+      });
+    }
+
+    function createInstrumentLabel(instrument, instrumentIndex) {
+      const label = document.createElement("button");
+      label.type = "button";
+      label.className = "instrument-label";
+      label.setAttribute("aria-label", instrument.name);
+      label.setAttribute("aria-pressed", "false");
+      label.innerHTML = symbolMarkup(instrument.name);
+      label.addEventListener("click", () => setActiveInstrument(instrumentIndex));
+      instrumentButtons.push(label);
+      return label;
+    }
+
+    function createStepCell(instrumentIndex, stepIndex) {
+      const stepButton = document.createElement("button");
+      stepButton.type = "button";
+      stepButton.className = "step-cell";
+      stepButton.dataset.instrument = String(instrumentIndex);
+      stepButton.dataset.step = String(stepIndex);
+      stepButton.setAttribute("aria-label", `${instruments[instrumentIndex].name} step ${stepIndex + 1}`);
+      stepButton.setAttribute("aria-pressed", "false");
+
+      if (isBlockEnd(stepIndex)) {
+        stepButton.classList.add("step-cell--block-end");
+      }
+
+      stepButton.addEventListener("click", () => {
+        pattern[instrumentIndex][stepIndex] = !pattern[instrumentIndex][stepIndex];
+        const isActive = pattern[instrumentIndex][stepIndex];
+        stepButton.classList.toggle("step-cell--active", isActive);
+        stepButton.setAttribute("aria-pressed", String(isActive));
+      });
+
+      return stepButton;
+    }
+
+    instruments.forEach((instrument, instrumentIndex) => {
+      sequencerMount.appendChild(createInstrumentLabel(instrument, instrumentIndex));
+
+      const row = document.createElement("div");
+      row.className = "step-row";
+
+      for (let stepIndex = 0; stepIndex < stepsPerInstrument; stepIndex += 1) {
+        row.appendChild(createStepCell(instrumentIndex, stepIndex));
+      }
+
+      sequencerMount.appendChild(row);
+    });
+
+    const addButton = document.createElement("button");
+    addButton.type = "button";
+    addButton.className = "add-instrument-button";
+    addButton.setAttribute("aria-label", "Add instrument");
+    addButton.textContent = "+";
+    sequencerMount.appendChild(addButton);
+
+    const numberRow = document.createElement("div");
+    numberRow.className = "step-numbers";
+
+    for (let stepIndex = 0; stepIndex < stepsPerInstrument; stepIndex += 1) {
+      const stepNumber = document.createElement("span");
+      stepNumber.className = "step-number";
+      stepNumber.textContent = String(stepIndex + 1);
+
+      if (isBlockEnd(stepIndex)) {
+        stepNumber.classList.add("step-number--block-end");
+      }
+
+      numberRow.appendChild(stepNumber);
+    }
+
+    sequencerMount.appendChild(numberRow);
+    setActiveInstrument(0);
+  }
+
   // Keep each fader's displayed level in sync with its current value.
   function updateSliderLabel(index, value) {
     const valueLabel = constraintLevelLabels[index];

--- a/style.css
+++ b/style.css
@@ -22,7 +22,7 @@ body {
 
 .app-header,
 .app-main {
-  width: min(960px, 92vw);
+  width: 95%;
   margin: 0 auto;
 }
 
@@ -221,11 +221,127 @@ body {
   border-radius: 8px;
   flex: 1;
   min-height: 220px;
-  padding: 1rem;
+  padding: 0.75rem;
+  color: var(--text);
+}
+
+/* 3x32 sequencer grid with symbol rows, sizing vars, and 8-step separators */
+.step-sequencer {
+  --row-height: 34px;
+  --label-width: 38px;
+  --step-gap: 0.22rem;
+  --block-divider: 0.48rem;
+  width: 100%;
   display: grid;
-  place-items: center;
+  grid-template-columns: var(--label-width) minmax(0, 1fr);
+  grid-template-rows: repeat(3, var(--row-height)) var(--row-height);
+  column-gap: 0.42rem;
+  row-gap: 0.36rem;
+}
+
+.instrument-label {
+  width: var(--label-width);
+  height: 100%;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: #171c23;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
   color: var(--muted);
+  cursor: pointer;
+}
+
+.instrument-label:hover {
+  border-color: #4b5870;
+}
+
+.instrument-label:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.instrument-label svg {
+  width: 15px;
+  height: 15px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.instrument--active {
+  border-color: var(--accent);
+  background: #1b2432;
+  color: #cfe5ff;
+}
+
+.step-row,
+.step-numbers {
+  display: flex;
+  align-items: center;
+  gap: var(--step-gap);
+  min-width: 0;
+  height: var(--row-height);
+}
+
+.step-cell {
+  width: calc((100% - (31 * var(--step-gap)) - (3 * var(--block-divider))) / 32);
+  height: var(--row-height);
+  border: 1px solid #2f3744;
+  border-radius: 4px;
+  background: #232a34;
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+
+.step-cell:hover {
+  border-color: #4e5d72;
+}
+
+.step-cell:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.step-cell--active {
+  background: var(--accent);
+  border-color: #79b7ff;
+}
+
+.step-cell--block-end {
+  margin-right: var(--block-divider);
+}
+
+.add-instrument-button {
+  width: 100%;
+  height: 100%;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: #171c23;
+  color: var(--text);
+  font-size: 1.15rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.add-instrument-button:hover {
+  border-color: var(--accent);
+}
+
+.step-number {
+  width: calc((100% - (31 * var(--step-gap)) - (3 * var(--block-divider))) / 32);
+  flex: 0 0 auto;
   text-align: center;
+  font-size: 0.86rem;
+  line-height: 1;
+  color: var(--muted);
+}
+
+.step-number--block-end {
+  margin-right: var(--block-divider);
 }
 
 /* Constraint panel keeps all three faders and lock control grouped */
@@ -411,5 +527,12 @@ body {
 
   .try-this-bar {
     flex-wrap: wrap;
+  }
+
+  .step-sequencer {
+    --row-height: 26px;
+    --label-width: 30px;
+    --step-gap: 0.14rem;
+    --block-divider: 0.3rem;
   }
 }


### PR DESCRIPTION
## Description

This PR introduces the non-functional drum grid layout into the UI.

**Included in this phase:**

- 3-instrument grid (Kick, Snare, Hi-hat)
- 32 steps per instrument
- Step cells rendered in the main sequencer area
- Step numbering (1–32)
- Instrument column with symbols
- “+” instrument button
- Basic click-to-toggle visual state

No audio, playback timing, or constraint integration is implemented yet.

Closes #3 

## UI Preview

_Current interface state after adding the drum grid skeleton:_

<img width="959" height="437" alt="image" src="https://github.com/user-attachments/assets/dbe7ce8b-1e80-454b-a9a4-271478131885" />
