### PR TITLE
Implement initial constraint sliders, new tooltips, reset defaults for constraint sliders

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,10 +45,11 @@
               />
               <button
                 id="metronomeToggleButton"
-                class="metronome-toggle-button"
+                class="metronome-toggle-button has-tooltip"
                 type="button"
                 aria-label="Enable metronome"
                 aria-pressed="false"
+                data-tooltip="Metronome"
               >
                 <svg viewBox="0 0 24 24" aria-hidden="true">
                   <path d="M9.4 4.5h5.2l3.6 13.8H5.8z"></path>
@@ -87,14 +88,16 @@
 
         <div class="constraints-faders">
           <div class="constraint-control">
-            <label for="constraintSlider1" class="constraint-label">Loop Length</label>
+            <label
+              for="constraintSlider1"
+              class="constraint-label constraint-label--help"
+              data-tooltip="Controls how many steps the loop plays before repeating."
+            >Loop Length</label>
             <div class="constraint-fader-row">
               <div class="constraint-scale" aria-hidden="true">
-                <span>5</span>
-                <span>4</span>
-                <span>3</span>
-                <span>2</span>
-                <span>1</span>
+                <span title="Full 32-step loop">32</span>
+                <span title="Repeats after step 16">16</span>
+                <span title="Repeats after step 8">8</span>
               </div>
               <div class="constraint-fader">
                 <input
@@ -102,13 +105,13 @@
                   class="constraint-slider"
                   type="range"
                   min="1"
-                  max="5"
+                  max="3"
                   step="1"
-                  value="3"
+                  value="1"
                 />
               </div>
             </div>
-            <span id="constraintValue1" class="constraint-value constraint-level-value">Level: 3</span>
+            <span id="constraintValue1" class="constraint-value constraint-level-value">Loop: 8</span>
           </div>
 
           <div class="constraint-control">
@@ -162,14 +165,16 @@
           </div>
 
           <div class="constraint-control">
-            <label for="constraintSlider4" class="constraint-label">Kit Size</label>
+            <label
+              for="constraintSlider4"
+              class="constraint-label constraint-label--help"
+              data-tooltip="Limits how many instruments can be used in the pattern."
+            >Kit Size</label>
             <div class="constraint-fader-row">
               <div class="constraint-scale" aria-hidden="true">
-                <span>5</span>
-                <span>4</span>
-                <span>3</span>
-                <span>2</span>
-                <span>1</span>
+                <span title="All instruments available.">5</span>
+                <span title="First 4 instruments are available.">4</span>
+                <span title="Only the first 3 instruments are available.">3</span>
               </div>
               <div class="constraint-fader">
                 <input
@@ -177,13 +182,13 @@
                   class="constraint-slider"
                   type="range"
                   min="1"
-                  max="5"
+                  max="3"
                   step="1"
-                  value="3"
+                  value="1"
                 />
               </div>
             </div>
-            <span id="constraintValue4" class="constraint-value constraint-level-value">Level: 3</span>
+            <span id="constraintValue4" class="constraint-value constraint-level-value">Kit: 3</span>
           </div>
 
           <div class="constraint-control">
@@ -242,6 +247,9 @@
             <input id="lock-sliders" class="lock-checkbox" type="checkbox" />
             <span>Lock sliders</span>
           </label>
+          <button id="resetConstraintsButton" class="constraints-reset-button" type="button">
+            Reset Defaults
+          </button>
         </div>
       </aside>
     </section>

--- a/script.js
+++ b/script.js
@@ -16,6 +16,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const bpmInput = document.getElementById("bpmInput");
   const metronomeToggleButton = document.getElementById("metronomeToggleButton");
   const clearPatternButton = document.getElementById("clearPatternButton");
+  const resetConstraintsButton = document.getElementById("resetConstraintsButton");
   const constraintSliders = Array.from(document.querySelectorAll(".constraint-slider"));
   const constraintLevelLabels = Array.from(
     document.querySelectorAll(".constraint-level-value")
@@ -52,7 +53,12 @@ document.addEventListener("DOMContentLoaded", () => {
     openhat: "assets/audio/openhat.wav",
   };
   const instrumentBufferKeys = ["kick", "snare", "hihat", "perc", "openhat"];
-  const PATTERN_STORAGE_KEY = "constraintlab.pattern.v1";
+  const PATTERN_STORAGE_KEY = "constraintlab.pattern";
+  const CONSTRAINT_STORAGE_KEY = "constraintlab.constraints";
+  const LOOP_LENGTH_OPTIONS = [8, 16, 32];
+  const LOOP_LENGTH_SLIDER_INDEX = 0;
+  const KIT_SIZE_OPTIONS = [3, 4, 5];
+  const KIT_SIZE_SLIDER_INDEX = 3;
 
   Object.entries(instrumentGainNodes).forEach(([instrumentKey, gainNode]) => {
     if (!gainNode) return;
@@ -108,18 +114,30 @@ document.addEventListener("DOMContentLoaded", () => {
     { name: "Perc" },
     { name: "Open-hat" },
   ];
+  const instrumentTooltips = {
+    Kick: "Kick - the low drum that provides the main pulse of the beat.",
+    Snare: "Snare - a sharp drum sound that adds impact and rhythm to a beat.",
+    "Hi-hat": "Hi-hat - a short, crisp cymbal sound often used to keep the rhythm moving.",
+    Perc: "Percussion - a small rhythmic accent used to add groove and variation.",
+    "Open-hat": "Open hi-hat - a longer cymbal sound that adds energy and movement.",
+  };
   const stepsPerInstrument = 32;
   const pattern = Array.from({ length: instruments.length }, () =>
     Array(stepsPerInstrument).fill(false)
   );
   const stepCellsByColumn = Array.from({ length: stepsPerInstrument }, () => []);
+  const stepCellsByInstrument = Array.from({ length: instruments.length }, () => []);
   const allStepCells = [];
+  const stepNumberElements = [];
+  const instrumentButtons = [];
 
   let isPlaying = false;
   let playbackTimerId = null;
   let currentStepIndex = 0;
   let previousStepIndex = -1;
   let isMetronomeOn = false;
+  let loopLength = 8;
+  let kitSize = 3;
 
   // Persist only the step matrix so edits survive reloads until the user clears them.
   function savePatternToStorage() {
@@ -151,6 +169,46 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   loadPatternFromStorage();
+
+  function saveConstraintValuesToStorage() {
+    try {
+      const sliderState = {};
+      constraintSliders.forEach((slider) => {
+        if (!slider.id) return;
+        sliderState[slider.id] = slider.value;
+      });
+      window.localStorage.setItem(CONSTRAINT_STORAGE_KEY, JSON.stringify(sliderState));
+    } catch {
+      // Ignore storage write failures and keep controls usable.
+    }
+  }
+
+  function loadConstraintValuesFromStorage() {
+    try {
+      const rawState = window.localStorage.getItem(CONSTRAINT_STORAGE_KEY);
+      if (!rawState) return;
+
+      const parsedState = JSON.parse(rawState);
+      if (!parsedState || typeof parsedState !== "object") return;
+
+      constraintSliders.forEach((slider) => {
+        if (!slider.id) return;
+
+        const savedValue = parsedState[slider.id];
+        if (savedValue === undefined) return;
+
+        const min = Number(slider.min);
+        const max = Number(slider.max);
+        const numericValue = Number(savedValue);
+        if (!Number.isFinite(numericValue)) return;
+
+        const clampedValue = Math.min(max, Math.max(min, numericValue));
+        slider.value = String(clampedValue);
+      });
+    } catch {
+      // Ignore invalid saved data and keep default slider values.
+    }
+  }
 
   function setPlaybackButtonState(playing) {
     if (!playbackToggleButton) return;
@@ -249,13 +307,14 @@ document.addEventListener("DOMContentLoaded", () => {
     setPlayhead(currentStepIndex);
 
     instruments.forEach((_, instrumentIndex) => {
+      if (instrumentIndex >= kitSize) return;
       if (!pattern[instrumentIndex][currentStepIndex]) return;
 
       const bufferKey = instrumentBufferKeys[instrumentIndex];
       playDrum(drumBuffers[bufferKey], instrumentGainNodes[bufferKey], tickTime);
     });
 
-    currentStepIndex = (currentStepIndex + 1) % stepsPerInstrument;
+    currentStepIndex = (currentStepIndex + 1) % loopLength;
   }
 
   async function startPlayback() {
@@ -331,8 +390,11 @@ document.addEventListener("DOMContentLoaded", () => {
     if (!isSpace) return;
 
     const target = document.activeElement;
+    if (target instanceof HTMLInputElement && target.type !== "range") {
+      return;
+    }
+
     if (
-      target instanceof HTMLInputElement ||
       target instanceof HTMLTextAreaElement ||
       target instanceof HTMLSelectElement ||
       (target instanceof HTMLElement && target.isContentEditable)
@@ -341,20 +403,82 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     event.preventDefault();
-    if (target instanceof HTMLElement && target.classList.contains("step-cell")) {
+    if (
+      target instanceof HTMLElement &&
+      (target.classList.contains("step-cell") || target.classList.contains("constraint-slider"))
+    ) {
       target.blur();
     }
     togglePlayback();
   });
 
   function auditionInstrument(instrumentIndex) {
+    if (instrumentIndex >= kitSize) return;
     const bufferKey = instrumentBufferKeys[instrumentIndex];
     playDrum(drumBuffers[bufferKey], instrumentGainNodes[bufferKey]);
   }
 
-  if (sequencerMount) {
-    const instrumentButtons = [];
+  function readLoopLengthFromSliderValue(sliderValue) {
+    const sliderIndex = Math.max(1, Math.min(3, Number(sliderValue)));
+    return LOOP_LENGTH_OPTIONS[sliderIndex - 1];
+  }
 
+  function updateLoopLengthState() {
+    const loopSlider = constraintSliders[LOOP_LENGTH_SLIDER_INDEX];
+    if (!loopSlider) return;
+
+    loopLength = readLoopLengthFromSliderValue(loopSlider.value);
+
+    allStepCells.forEach((cell) => {
+      const stepIndex = Number(cell.dataset.step);
+      const instrumentIndex = Number(cell.dataset.instrument);
+      const isStepLocked = stepIndex >= loopLength;
+      const isRowLocked = instrumentIndex >= kitSize;
+      cell.classList.toggle("step-cell--locked", isStepLocked);
+      cell.setAttribute("aria-disabled", String(isStepLocked || isRowLocked));
+    });
+
+    stepNumberElements.forEach((numberElement, stepIndex) => {
+      numberElement.classList.toggle("step-number--locked", stepIndex >= loopLength);
+    });
+
+    if (currentStepIndex >= loopLength) {
+      clearPlayhead();
+      currentStepIndex = 0;
+    }
+  }
+
+  function readKitSizeFromSliderValue(sliderValue) {
+    const sliderIndex = Math.max(1, Math.min(3, Number(sliderValue)));
+    return KIT_SIZE_OPTIONS[sliderIndex - 1];
+  }
+
+  function updateKitSizeState() {
+    const kitSlider = constraintSliders[KIT_SIZE_SLIDER_INDEX];
+    if (!kitSlider) return;
+
+    kitSize = readKitSizeFromSliderValue(kitSlider.value);
+
+    instrumentButtons.forEach((button, instrumentIndex) => {
+      const isLocked = instrumentIndex >= kitSize;
+      button.classList.toggle("instrument-label--locked", isLocked);
+      if (isLocked) {
+        button.classList.remove("instrument--active");
+        button.setAttribute("aria-pressed", "false");
+      }
+      button.setAttribute("aria-disabled", String(isLocked));
+    });
+
+    stepCellsByInstrument.forEach((rowCells, instrumentIndex) => {
+      const isLocked = instrumentIndex >= kitSize;
+      rowCells.forEach((cell) => {
+        cell.classList.toggle("step-cell--row-locked", isLocked);
+        cell.setAttribute("aria-disabled", String(isLocked || Number(cell.dataset.step) >= loopLength));
+      });
+    });
+  }
+
+  if (sequencerMount) {
     // Mark the end of each 4-step block for visual grouping only.
     function isBlockEnd(stepIndex) {
       return (stepIndex + 1) % 4 === 0 && stepIndex !== stepsPerInstrument - 1;
@@ -423,11 +547,13 @@ document.addEventListener("DOMContentLoaded", () => {
     function createInstrumentLabel(instrument, instrumentIndex) {
       const label = document.createElement("button");
       label.type = "button";
-      label.className = "instrument-label";
+      label.className = "instrument-label has-tooltip";
       label.setAttribute("aria-label", instrument.name);
       label.setAttribute("aria-pressed", "false");
+      label.setAttribute("data-tooltip", instrumentTooltips[instrument.name] || instrument.name);
       label.innerHTML = symbolMarkup(instrument.name);
       label.addEventListener("click", () => {
+        if (instrumentIndex >= kitSize) return;
         setActiveInstrument(instrumentIndex);
         auditionInstrument(instrumentIndex);
       });
@@ -454,6 +580,8 @@ document.addEventListener("DOMContentLoaded", () => {
       }
 
       stepButton.addEventListener("click", () => {
+        if (stepIndex >= loopLength || instrumentIndex >= kitSize) return;
+
         pattern[instrumentIndex][stepIndex] = !pattern[instrumentIndex][stepIndex];
         const isActive = pattern[instrumentIndex][stepIndex];
         stepButton.classList.toggle("step-cell--active", isActive);
@@ -466,6 +594,7 @@ document.addEventListener("DOMContentLoaded", () => {
       });
 
       stepCellsByColumn[stepIndex].push(stepButton);
+      stepCellsByInstrument[instrumentIndex].push(stepButton);
       allStepCells.push(stepButton);
       return stepButton;
     }
@@ -500,6 +629,7 @@ document.addEventListener("DOMContentLoaded", () => {
         stepNumber.classList.add("step-number--block-end");
       }
 
+      stepNumberElements.push(stepNumber);
       numberRow.appendChild(stepNumber);
     }
 
@@ -525,6 +655,17 @@ document.addEventListener("DOMContentLoaded", () => {
   function updateSliderLabel(index, value) {
     const valueLabel = constraintLevelLabels[index];
     if (!valueLabel) return;
+
+    if (index === LOOP_LENGTH_SLIDER_INDEX) {
+      valueLabel.textContent = `Loop: ${readLoopLengthFromSliderValue(value)}`;
+      return;
+    }
+
+    if (index === KIT_SIZE_SLIDER_INDEX) {
+      valueLabel.textContent = `Kit: ${readKitSizeFromSliderValue(value)}`;
+      return;
+    }
+
     valueLabel.textContent = `Level: ${value}`;
   }
 
@@ -532,21 +673,50 @@ document.addEventListener("DOMContentLoaded", () => {
   function setAllSliderValues(value) {
     constraintSliders.forEach((slider, index) => {
       slider.value = value;
-      updateSliderLabel(index, value);
+      updateSliderLabel(index, slider.value);
     });
   }
 
-  // Per-slider input handling: independent updates, or mirrored updates when locked.
+  // Per-slider input handling: update labels, apply loop/kit locking, and persist values.
+  loadConstraintValuesFromStorage();
+
   constraintSliders.forEach((slider, index) => {
     updateSliderLabel(index, slider.value);
 
     slider.addEventListener("input", () => {
       if (lockSlidersCheckbox.checked) {
         setAllSliderValues(slider.value);
+        updateLoopLengthState();
+        updateKitSizeState();
+        saveConstraintValuesToStorage();
         return;
       }
 
       updateSliderLabel(index, slider.value);
+      if (index === LOOP_LENGTH_SLIDER_INDEX) {
+        updateLoopLengthState();
+      }
+      if (index === KIT_SIZE_SLIDER_INDEX) {
+        updateKitSizeState();
+      }
+      saveConstraintValuesToStorage();
     });
   });
+
+  if (resetConstraintsButton) {
+    resetConstraintsButton.addEventListener("click", () => {
+      constraintSliders.forEach((slider, index) => {
+        slider.value = slider.defaultValue;
+        updateSliderLabel(index, slider.value);
+      });
+
+      updateLoopLengthState();
+      updateKitSizeState();
+      saveConstraintValuesToStorage();
+    });
+  }
+
+  updateLoopLengthState();
+  updateKitSizeState();
 });
+

--- a/style.css
+++ b/style.css
@@ -47,7 +47,7 @@ body {
   min-height: 48px;
   border: 1px solid var(--border);
   border-radius: 8px;
-  overflow: hidden;
+  overflow: visible;
   margin-bottom: 1.25rem;
 }
 
@@ -344,6 +344,13 @@ body {
   color: #cfe5ff;
 }
 
+.instrument-label--locked {
+  background: #1a2028;
+  border-color: #2a303a;
+  color: #6f7887;
+  cursor: not-allowed;
+}
+
 .step-row,
 .step-numbers {
   display: flex;
@@ -386,6 +393,30 @@ body {
   box-shadow: inset 0 0 0 1px rgba(143, 184, 242, 0.35);
 }
 
+.step-cell--locked {
+  opacity: 0.45;
+  background: #1a2028;
+  border-color: #2a303a;
+  cursor: not-allowed;
+}
+
+.step-cell--locked.step-cell--active {
+  background: rgba(91, 167, 255, 0.32);
+  border-color: rgba(121, 183, 255, 0.45);
+}
+
+.step-cell--row-locked {
+  opacity: 0.45;
+  background: #1a2028;
+  border-color: #2a303a;
+  cursor: not-allowed;
+}
+
+.step-cell--row-locked.step-cell--active {
+  background: rgba(91, 167, 255, 0.32);
+  border-color: rgba(121, 183, 255, 0.45);
+}
+
 .step-cell--block-end {
   margin-right: var(--block-divider);
 }
@@ -397,6 +428,10 @@ body {
   font-size: 0.86rem;
   line-height: 1;
   color: var(--muted);
+}
+
+.step-number--locked {
+  opacity: 0.4;
 }
 
 .step-number--block-end {
@@ -448,6 +483,62 @@ body {
   font-size: 0.74rem;
   color: var(--text);
   text-align: center;
+  position: relative;
+}
+
+.constraint-label--help::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 0.4rem);
+  transform: translateX(-50%);
+  background: #0f1318;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.28rem 0.45rem;
+  color: var(--text);
+  font-size: 0.67rem;
+  line-height: 1.2;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+  z-index: 10;
+}
+
+.constraint-label--help:hover::after {
+  opacity: 1;
+}
+
+.has-tooltip {
+  position: relative;
+}
+
+.has-tooltip::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 0.4rem);
+  transform: translateX(-50%);
+  background: #0f1318;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.28rem 0.45rem;
+  color: var(--text);
+  font-size: 0.67rem;
+  line-height: 1.25;
+  white-space: normal;
+  width: max-content;
+  max-width: 220px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+  z-index: 10;
+}
+
+.has-tooltip:hover::after,
+.has-tooltip:focus-visible::after {
+  opacity: 1;
 }
 
 .step-corner-spacer {
@@ -543,6 +634,10 @@ body {
   margin-top: 0.25rem;
   padding-top: 0.75rem;
   border-top: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
 }
 
 .lock-label {
@@ -558,6 +653,28 @@ body {
   width: 14px;
   height: 14px;
   accent-color: var(--accent);
+}
+
+.constraints-reset-button {
+  background: #1e2430;
+  color: var(--muted);
+  border: 1px solid #4a5569;
+  border-radius: 4px;
+  font: inherit;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  padding: 0.24rem 0.55rem;
+  cursor: pointer;
+}
+
+.constraints-reset-button:hover {
+  border-color: #64748f;
+  color: var(--text);
+}
+
+.constraints-reset-button:focus {
+  outline: none;
 }
 
 /* Small-screen fallback: stack grid and constraints vertically */
@@ -581,3 +698,15 @@ body {
     width: 100%;
   }
 }
+
+.instrument-label.has-tooltip::after {
+  left: -110%;
+  transform: none;
+  margin-left: 0;
+}
+
+.instrument-label.has-tooltip:hover::after,
+.instrument-label.has-tooltip:focus-visible::after {
+  transition-delay: 0.5s;
+}
+


### PR DESCRIPTION
## Description

This PR introduces the first functional constraint logic into ConstraintLab and a few other useful features.

It implements the **Loop Length** and **Kit Size** constraint sliders, tooltips to explain the constraints and instruments, and adds a "Reset Defaults" button to reset the constraint levels to their base values.

**Included in this phase:**

- Implementation of the **Loop Length** constraint slider  
  - Slider levels updated to **8 / 16 / 32 steps**  
  - Grid visually locks steps beyond the selected loop length  
  - Locked steps cannot be edited  
- Implementation of the **Kit Size** constraint slider  
  - Slider levels updated to **3 / 4 / 5 instruments**  
  - Instrument rows are visually locked when unavailable  
  - Patterns for locked instruments are preserved when re-enabled  
- Addition of **constraint tooltips**  
  - Hovering over constraint titles explains their purpose  
  - Hovering over slider levels explains what each level does  
- Addition of **instrument tooltips**  
  - Hovering over each instrument icon displays its name and a short beginner-friendly explanation  
- Addition of a **metronome tooltip**  
- Addition of a **Reset Defaults** button for constraint sliders  
  - Restores sliders to their default state  
- Constraint levels now **persist across page refresh**  

No additional constraint types, pattern generation logic, or suggestion logic is implemented in this phase.

Closes #9 