### PR TITLE
Implement Repetition constraint slider logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,14 +222,16 @@
           </div>
 
           <div class="constraint-control">
-            <label for="constraintSlider6" class="constraint-label">Repetition</label>
+            <label
+              for="constraintSlider6"
+              class="constraint-label constraint-label--help"
+              data-tooltip="Controls how much of the loop repeats earlier pattern sections."
+            >Repetition</label>
             <div class="constraint-fader-row">
               <div class="constraint-scale" aria-hidden="true">
-                <span>5</span>
-                <span>4</span>
-                <span>3</span>
-                <span>2</span>
-                <span>1</span>
+                <span title="No repetition is applied.">Free</span>
+                <span title="Most of the second half repeats the first, but the end is editable.">Partial</span>
+                <span title="The second half of the loop mirrors the first half.">Strong</span>
               </div>
               <div class="constraint-fader">
                 <input
@@ -237,13 +239,13 @@
                   class="constraint-slider"
                   type="range"
                   min="1"
-                  max="5"
+                  max="3"
                   step="1"
                   value="3"
                 />
               </div>
             </div>
-            <span id="constraintValue6" class="constraint-value constraint-level-value">Level: 3</span>
+            <span id="constraintValue6" class="constraint-value constraint-level-value">Repetition: Free</span>
           </div>
         </div>
 

--- a/script.js
+++ b/script.js
@@ -62,6 +62,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const LOOP_LENGTH_SLIDER_INDEX = 0;
   const GRID_RESOLUTION_OPTIONS = ["coarse", "medium", "fine"];
   const GRID_RESOLUTION_SLIDER_INDEX = 1;
+  const REPETITION_LEVELS = ["strong", "partial", "free"];
+  const REPETITION_SLIDER_INDEX = 5;
   const KIT_SIZE_OPTIONS = [3, 4, 5];
   const KIT_SIZE_SLIDER_INDEX = 3;
   const DENSITY_LEVELS = ["sparse", "moderate", "dense", "free"];
@@ -134,6 +136,9 @@ document.addEventListener("DOMContentLoaded", () => {
   );
   const stepCellsByColumn = Array.from({ length: stepsPerInstrument }, () => []);
   const stepCellsByInstrument = Array.from({ length: instruments.length }, () => []);
+  const repetitionScope = Array.from({ length: instruments.length }, () =>
+    Array(stepsPerInstrument).fill(false)
+  );
   const allStepCells = [];
   const stepNumberElements = [];
   const instrumentButtons = [];
@@ -147,6 +152,7 @@ document.addEventListener("DOMContentLoaded", () => {
   let gridResolutionLevel = "fine";
   let kitSize = 3;
   let densityLevel = "moderate";
+  let repetitionLevel = "free";
   let isOverDensityLimit = false;
   let tryThisMessageTimeoutId = null;
   let persistentTryMessage = baseTryThisMessage;
@@ -321,7 +327,7 @@ document.addEventListener("DOMContentLoaded", () => {
     instruments.forEach((_, instrumentIndex) => {
       if (instrumentIndex >= kitSize) return;
       if (!isStepAllowedByGridResolution(currentStepIndex)) return;
-      if (!pattern[instrumentIndex][currentStepIndex]) return;
+      if (!isEffectiveStepActive(instrumentIndex, currentStepIndex)) return;
 
       const bufferKey = instrumentBufferKeys[instrumentIndex];
       playDrum(drumBuffers[bufferKey], instrumentGainNodes[bufferKey], tickTime);
@@ -403,7 +409,11 @@ document.addEventListener("DOMContentLoaded", () => {
     if (!isSpace) return;
 
     const target = document.activeElement;
-    if (target instanceof HTMLInputElement && target.type !== "range") {
+    if (
+      target instanceof HTMLInputElement &&
+      target.type !== "range" &&
+      target.type !== "checkbox"
+    ) {
       return;
     }
 
@@ -419,6 +429,9 @@ document.addEventListener("DOMContentLoaded", () => {
     if (
       target instanceof HTMLElement &&
       (
+        target.classList.contains("playback-toggle-button") ||
+        target.classList.contains("clear-button") ||
+        target.classList.contains("lock-checkbox") ||
         target.classList.contains("step-cell") ||
         target.classList.contains("constraint-slider") ||
         target.classList.contains("instrument-label")
@@ -445,6 +458,98 @@ document.addEventListener("DOMContentLoaded", () => {
     return GRID_RESOLUTION_OPTIONS[sliderIndex - 1];
   }
 
+  function readRepetitionLevelFromSliderValue(sliderValue) {
+    const sliderIndex = Math.max(1, Math.min(3, Number(sliderValue)));
+    return REPETITION_LEVELS[sliderIndex - 1];
+  }
+
+  function getRepetitionSourceStepForLevel(stepIndex, level) {
+    if (stepIndex >= loopLength || level === "free") return null;
+
+    const halfLength = loopLength / 2;
+    if (level === "strong") {
+      return stepIndex >= halfLength ? stepIndex - halfLength : null;
+    }
+
+    const mirroredLength = loopLength / 4;
+    const mirroredStart = halfLength;
+    const mirroredEnd = mirroredStart + mirroredLength;
+    return stepIndex >= mirroredStart && stepIndex < mirroredEnd
+      ? stepIndex - halfLength
+      : null;
+  }
+
+  function getRepetitionSourceStep(stepIndex) {
+    return getRepetitionSourceStepForLevel(stepIndex, repetitionLevel);
+  }
+
+  function isCellCurrentlyAvailable(instrumentIndex, stepIndex) {
+    return (
+      instrumentIndex < kitSize &&
+      stepIndex < loopLength &&
+      isStepAllowedByGridResolution(stepIndex)
+    );
+  }
+
+  function createRepetitionScopeMap(level) {
+    const nextScope = Array.from({ length: instruments.length }, () =>
+      Array(stepsPerInstrument).fill(false)
+    );
+
+    if (level === "free") {
+      return nextScope;
+    }
+
+    for (let instrumentIndex = 0; instrumentIndex < kitSize; instrumentIndex += 1) {
+      for (let stepIndex = 0; stepIndex < loopLength; stepIndex += 1) {
+        if (!isStepAllowedByGridResolution(stepIndex)) continue;
+        nextScope[instrumentIndex][stepIndex] = true;
+      }
+    }
+
+    return nextScope;
+  }
+
+  function applyRepetitionScope(nextScope) {
+    repetitionScope.forEach((row, instrumentIndex) => {
+      row.forEach((_, stepIndex) => {
+        repetitionScope[instrumentIndex][stepIndex] = Boolean(nextScope[instrumentIndex][stepIndex]);
+      });
+    });
+  }
+
+  function isStepDerivedByRepetition(instrumentIndex, stepIndex, scope = repetitionScope) {
+    return Boolean(scope[instrumentIndex][stepIndex]) && getRepetitionSourceStep(stepIndex) !== null;
+  }
+
+  function isEffectiveStepActiveForLevel(
+    instrumentIndex,
+    stepIndex,
+    level,
+    scope = repetitionScope
+  ) {
+    const isInActiveRegion = isCellCurrentlyAvailable(instrumentIndex, stepIndex);
+
+    if (!isInActiveRegion) {
+      return Boolean(pattern[instrumentIndex][stepIndex]);
+    }
+
+    if (!scope[instrumentIndex][stepIndex]) {
+      return Boolean(pattern[instrumentIndex][stepIndex]);
+    }
+
+    const sourceStepIndex = getRepetitionSourceStepForLevel(stepIndex, level);
+    if (sourceStepIndex !== null && !isStepAllowedByGridResolution(sourceStepIndex)) {
+      return false;
+    }
+    const effectiveStepIndex = sourceStepIndex === null ? stepIndex : sourceStepIndex;
+    return Boolean(pattern[instrumentIndex][effectiveStepIndex]);
+  }
+
+  function isEffectiveStepActive(instrumentIndex, stepIndex) {
+    return isEffectiveStepActiveForLevel(instrumentIndex, stepIndex, repetitionLevel);
+  }
+
   function isStepAllowedByGridResolution(stepIndex) {
     const stepNumber = stepIndex + 1;
 
@@ -460,10 +565,19 @@ document.addEventListener("DOMContentLoaded", () => {
       const isStepLocked = stepIndex >= loopLength;
       const isRowLocked = instrumentIndex >= kitSize;
       const isResolutionLocked = !isStepLocked && !isStepAllowedByGridResolution(stepIndex);
+      const isDerived =
+        !isStepLocked &&
+        !isRowLocked &&
+        !isResolutionLocked &&
+        isStepDerivedByRepetition(instrumentIndex, stepIndex);
       cell.classList.toggle("step-cell--locked", isStepLocked);
       cell.classList.toggle("step-cell--row-locked", isRowLocked);
       cell.classList.toggle("step-cell--resolution-locked", isResolutionLocked);
-      cell.setAttribute("aria-disabled", String(isStepLocked || isRowLocked || isResolutionLocked));
+      cell.classList.toggle("step-cell--derived", isDerived);
+      cell.setAttribute(
+        "aria-disabled",
+        String(isStepLocked || isRowLocked || isResolutionLocked || isDerived)
+      );
     });
 
     stepNumberElements.forEach((numberElement, stepIndex) => {
@@ -472,6 +586,8 @@ document.addEventListener("DOMContentLoaded", () => {
       numberElement.classList.toggle("step-number--locked", isStepLocked);
       numberElement.classList.toggle("step-number--resolution-locked", isResolutionLocked);
     });
+
+    refreshEffectivePatternState();
   }
 
   function updateLoopLengthState() {
@@ -497,6 +613,82 @@ document.addEventListener("DOMContentLoaded", () => {
     gridResolutionLevel = readGridResolutionFromSliderValue(gridSlider.value);
     refreshStepAvailabilityState();
     updateDensityState();
+  }
+
+  function updateRepetitionState(options = {}) {
+    const { silent = false } = options;
+    const repetitionSlider = constraintSliders[REPETITION_SLIDER_INDEX];
+    if (!repetitionSlider) return;
+
+    const previousLevel = repetitionLevel;
+    const nextLevel = readRepetitionLevelFromSliderValue(repetitionSlider.value);
+    const previousScope = repetitionScope.map((row) => row.slice());
+    const nextScope = createRepetitionScopeMap(nextLevel);
+    let shouldShowRepetitionMessage = false;
+
+    if (nextLevel === "strong" || nextLevel === "partial") {
+      for (let instrumentIndex = 0; instrumentIndex < kitSize; instrumentIndex += 1) {
+        for (let stepIndex = 0; stepIndex < loopLength; stepIndex += 1) {
+          if (!isStepAllowedByGridResolution(stepIndex)) continue;
+
+          const wasActive = isEffectiveStepActiveForLevel(
+            instrumentIndex,
+            stepIndex,
+            previousLevel,
+            previousScope
+          );
+          const willBeActive = isEffectiveStepActiveForLevel(
+            instrumentIndex,
+            stepIndex,
+            nextLevel,
+            nextScope
+          );
+
+          if (wasActive !== willBeActive) {
+            shouldShowRepetitionMessage = true;
+            break;
+          }
+        }
+
+        if (shouldShowRepetitionMessage) {
+          break;
+        }
+      }
+    }
+
+    for (let instrumentIndex = 0; instrumentIndex < instruments.length; instrumentIndex += 1) {
+      for (let stepIndex = 0; stepIndex < stepsPerInstrument; stepIndex += 1) {
+        const wasDerived =
+          previousScope[instrumentIndex][stepIndex] &&
+          getRepetitionSourceStepForLevel(stepIndex, previousLevel) !== null;
+        const isDerived =
+          nextScope[instrumentIndex][stepIndex] &&
+          getRepetitionSourceStepForLevel(stepIndex, nextLevel) !== null;
+        if (!wasDerived || isDerived) continue;
+
+        pattern[instrumentIndex][stepIndex] = isEffectiveStepActiveForLevel(
+          instrumentIndex,
+          stepIndex,
+          previousLevel,
+          previousScope
+        );
+      }
+    }
+
+    repetitionLevel = nextLevel;
+    applyRepetitionScope(nextScope);
+    refreshStepAvailabilityState();
+    savePatternToStorage();
+    updateDensityState();
+
+    if (!silent && shouldShowRepetitionMessage) {
+      showTemporaryTryMessage(
+        nextLevel === "strong"
+          ? "Repetition applied: second half now mirrors the first."
+          : "Repetition applied: part of the second half now mirrors part of the first.",
+        4500
+      );
+    }
   }
 
   function readKitSizeFromSliderValue(sliderValue) {
@@ -542,7 +734,7 @@ document.addEventListener("DOMContentLoaded", () => {
     for (let instrumentIndex = 0; instrumentIndex < kitSize; instrumentIndex += 1) {
       for (let stepIndex = 0; stepIndex < loopLength; stepIndex += 1) {
         if (!isStepAllowedByGridResolution(stepIndex)) continue;
-        if (pattern[instrumentIndex][stepIndex]) {
+        if (isEffectiveStepActive(instrumentIndex, stepIndex)) {
           count += 1;
         }
       }
@@ -612,6 +804,26 @@ document.addEventListener("DOMContentLoaded", () => {
     }, 280);
   }
 
+  function triggerDerivedStepFeedback(stepCell) {
+    stepCell.classList.remove("step-cell--derived-feedback");
+    void stepCell.offsetWidth;
+    stepCell.classList.add("step-cell--derived-feedback");
+
+    window.setTimeout(() => {
+      stepCell.classList.remove("step-cell--derived-feedback");
+    }, 280);
+  }
+
+  function refreshEffectivePatternState() {
+    allStepCells.forEach((cell) => {
+      const instrumentIndex = Number(cell.dataset.instrument);
+      const stepIndex = Number(cell.dataset.step);
+      const isActive = isEffectiveStepActive(instrumentIndex, stepIndex);
+      cell.classList.toggle("step-cell--active", isActive);
+      cell.setAttribute("aria-pressed", String(isActive));
+    });
+  }
+
   function updateDensityState() {
     const densitySlider = constraintSliders[DENSITY_SLIDER_INDEX];
     if (!densitySlider) return;
@@ -651,7 +863,7 @@ document.addEventListener("DOMContentLoaded", () => {
     allStepCells.forEach((cell) => {
       const instrumentIndex = Number(cell.dataset.instrument);
       const stepIndex = Number(cell.dataset.step);
-      const isActive = pattern[instrumentIndex][stepIndex];
+      const isActive = isEffectiveStepActive(instrumentIndex, stepIndex);
       const inActiveRegion =
         instrumentIndex < kitSize &&
         stepIndex < loopLength &&
@@ -773,6 +985,11 @@ document.addEventListener("DOMContentLoaded", () => {
           return;
         }
 
+        if (isStepDerivedByRepetition(instrumentIndex, stepIndex)) {
+          triggerDerivedStepFeedback(stepButton);
+          return;
+        }
+
         const isCurrentlyActive = pattern[instrumentIndex][stepIndex];
         if (!isCurrentlyActive) {
           const compliance = getDensityComplianceState();
@@ -797,8 +1014,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
         pattern[instrumentIndex][stepIndex] = !isCurrentlyActive;
         const isActive = pattern[instrumentIndex][stepIndex];
-        stepButton.classList.toggle("step-cell--active", isActive);
-        stepButton.setAttribute("aria-pressed", String(isActive));
+        refreshEffectivePatternState();
         savePatternToStorage();
         updateDensityState();
 
@@ -862,6 +1078,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       previousStepIndex = -1;
       savePatternToStorage();
+      refreshEffectivePatternState();
       updateDensityState();
     });
   }
@@ -893,6 +1110,12 @@ document.addEventListener("DOMContentLoaded", () => {
       return;
     }
 
+    if (index === REPETITION_SLIDER_INDEX) {
+      const level = readRepetitionLevelFromSliderValue(value);
+      valueLabel.textContent = `Repetition: ${level.charAt(0).toUpperCase() + level.slice(1)}`;
+      return;
+    }
+
     valueLabel.textContent = `Level: ${value}`;
   }
 
@@ -916,6 +1139,7 @@ document.addEventListener("DOMContentLoaded", () => {
         updateLoopLengthState();
         updateGridResolutionState();
         updateKitSizeState();
+        updateRepetitionState();
         saveConstraintValuesToStorage();
         return;
       }
@@ -933,6 +1157,9 @@ document.addEventListener("DOMContentLoaded", () => {
       if (index === DENSITY_SLIDER_INDEX) {
         updateDensityState();
       }
+      if (index === REPETITION_SLIDER_INDEX) {
+        updateRepetitionState();
+      }
       saveConstraintValuesToStorage();
     });
   });
@@ -947,6 +1174,7 @@ document.addEventListener("DOMContentLoaded", () => {
       updateLoopLengthState();
       updateGridResolutionState();
       updateKitSizeState();
+      updateRepetitionState({ silent: true });
       saveConstraintValuesToStorage();
     });
   }
@@ -954,5 +1182,6 @@ document.addEventListener("DOMContentLoaded", () => {
   updateLoopLengthState();
   updateGridResolutionState();
   updateKitSizeState();
+  updateRepetitionState({ silent: true });
 });
 

--- a/script.js
+++ b/script.js
@@ -106,7 +106,7 @@ document.addEventListener("DOMContentLoaded", () => {
       return;
     }
 
-    // Create a new source for each hit so simultaneous notes can overlap correctly.
+    // Create a new source for each hit so notes can overlap on the same step.
     const source = audioContext.createBufferSource();
     source.buffer = buffer;
     source.connect(gainNode || audioContext.destination);
@@ -136,9 +136,6 @@ document.addEventListener("DOMContentLoaded", () => {
   );
   const stepCellsByColumn = Array.from({ length: stepsPerInstrument }, () => []);
   const stepCellsByInstrument = Array.from({ length: instruments.length }, () => []);
-  const repetitionScope = Array.from({ length: instruments.length }, () =>
-    Array(stepsPerInstrument).fill(false)
-  );
   const allStepCells = [];
   const stepNumberElements = [];
   const instrumentButtons = [];
@@ -491,14 +488,10 @@ document.addEventListener("DOMContentLoaded", () => {
     );
   }
 
-  function createRepetitionScopeMap(level) {
+  function createActiveScopeMap() {
     const nextScope = Array.from({ length: instruments.length }, () =>
       Array(stepsPerInstrument).fill(false)
     );
-
-    if (level === "free") {
-      return nextScope;
-    }
 
     for (let instrumentIndex = 0; instrumentIndex < kitSize; instrumentIndex += 1) {
       for (let stepIndex = 0; stepIndex < loopLength; stepIndex += 1) {
@@ -510,31 +503,14 @@ document.addEventListener("DOMContentLoaded", () => {
     return nextScope;
   }
 
-  function applyRepetitionScope(nextScope) {
-    repetitionScope.forEach((row, instrumentIndex) => {
-      row.forEach((_, stepIndex) => {
-        repetitionScope[instrumentIndex][stepIndex] = Boolean(nextScope[instrumentIndex][stepIndex]);
-      });
-    });
+  function isStepDerivedByRepetition(instrumentIndex, stepIndex) {
+    return isCellCurrentlyAvailable(instrumentIndex, stepIndex) && getRepetitionSourceStep(stepIndex) !== null;
   }
 
-  function isStepDerivedByRepetition(instrumentIndex, stepIndex, scope = repetitionScope) {
-    return Boolean(scope[instrumentIndex][stepIndex]) && getRepetitionSourceStep(stepIndex) !== null;
-  }
-
-  function isEffectiveStepActiveForLevel(
-    instrumentIndex,
-    stepIndex,
-    level,
-    scope = repetitionScope
-  ) {
+  function isEffectiveStepActiveForLevel(instrumentIndex, stepIndex, level) {
     const isInActiveRegion = isCellCurrentlyAvailable(instrumentIndex, stepIndex);
 
     if (!isInActiveRegion) {
-      return Boolean(pattern[instrumentIndex][stepIndex]);
-    }
-
-    if (!scope[instrumentIndex][stepIndex]) {
       return Boolean(pattern[instrumentIndex][stepIndex]);
     }
 
@@ -548,6 +524,68 @@ document.addEventListener("DOMContentLoaded", () => {
 
   function isEffectiveStepActive(instrumentIndex, stepIndex) {
     return isEffectiveStepActiveForLevel(instrumentIndex, stepIndex, repetitionLevel);
+  }
+
+  function getRepetitionAppliedMessage(level = repetitionLevel) {
+    return level === "strong"
+      ? "Repetition applied: second half now mirrors the first."
+      : "Repetition applied: part of the second half now mirrors part of the first.";
+  }
+
+  function captureVisibleRepetitionOverrideSnapshot() {
+    const overrideStates = [];
+
+    for (let instrumentIndex = 0; instrumentIndex < kitSize; instrumentIndex += 1) {
+      for (let stepIndex = 0; stepIndex < loopLength; stepIndex += 1) {
+        if (!isStepAllowedByGridResolution(stepIndex)) continue;
+
+        const sourceStepIndex = getRepetitionSourceStep(stepIndex);
+        if (sourceStepIndex === null) continue;
+
+        const storedValue = Boolean(pattern[instrumentIndex][stepIndex]);
+        const effectiveValue = isEffectiveStepActive(instrumentIndex, stepIndex);
+        if (storedValue === effectiveValue) continue;
+
+        overrideStates.push(`${instrumentIndex}:${stepIndex}:${effectiveValue ? 1 : 0}`);
+      }
+    }
+
+    return overrideStates.join("|");
+  }
+
+  function maybeShowRepetitionScopeChangeMessage(previousSnapshot, silent = false) {
+    if (silent) return;
+    if (repetitionLevel !== "strong" && repetitionLevel !== "partial") return;
+
+    const nextSnapshot = captureVisibleRepetitionOverrideSnapshot();
+    if (!nextSnapshot || previousSnapshot === nextSnapshot) return;
+
+    showTemporaryTryMessage(getRepetitionAppliedMessage(), 4500);
+  }
+
+  function willStepBeDerived(stepIndex, level) {
+    return getRepetitionSourceStepForLevel(stepIndex, level) !== null;
+  }
+
+  function getProjectedStepStateForRepetitionChange(
+    instrumentIndex,
+    stepIndex,
+    previousLevel,
+    nextLevel,
+    activeScope
+  ) {
+    if (!activeScope[instrumentIndex][stepIndex]) {
+      return Boolean(pattern[instrumentIndex][stepIndex]);
+    }
+
+    const wasDerived = willStepBeDerived(stepIndex, previousLevel);
+    const willBeDerived = willStepBeDerived(stepIndex, nextLevel);
+
+    if (wasDerived && !willBeDerived) {
+      return isEffectiveStepActiveForLevel(instrumentIndex, stepIndex, previousLevel);
+    }
+
+    return isEffectiveStepActiveForLevel(instrumentIndex, stepIndex, nextLevel);
   }
 
   function isStepAllowedByGridResolution(stepIndex) {
@@ -590,9 +628,11 @@ document.addEventListener("DOMContentLoaded", () => {
     refreshEffectivePatternState();
   }
 
-  function updateLoopLengthState() {
+  function updateLoopLengthState(options = {}) {
+    const { silent = false } = options;
     const loopSlider = constraintSliders[LOOP_LENGTH_SLIDER_INDEX];
     if (!loopSlider) return;
+    const previousSnapshot = captureVisibleRepetitionOverrideSnapshot();
 
     loopLength = readLoopLengthFromSliderValue(loopSlider.value);
 
@@ -604,15 +644,19 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     updateDensityState();
+    maybeShowRepetitionScopeChangeMessage(previousSnapshot, silent);
   }
 
-  function updateGridResolutionState() {
+  function updateGridResolutionState(options = {}) {
+    const { silent = false } = options;
     const gridSlider = constraintSliders[GRID_RESOLUTION_SLIDER_INDEX];
     if (!gridSlider) return;
+    const previousSnapshot = captureVisibleRepetitionOverrideSnapshot();
 
     gridResolutionLevel = readGridResolutionFromSliderValue(gridSlider.value);
     refreshStepAvailabilityState();
     updateDensityState();
+    maybeShowRepetitionScopeChangeMessage(previousSnapshot, silent);
   }
 
   function updateRepetitionState(options = {}) {
@@ -622,26 +666,21 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const previousLevel = repetitionLevel;
     const nextLevel = readRepetitionLevelFromSliderValue(repetitionSlider.value);
-    const previousScope = repetitionScope.map((row) => row.slice());
-    const nextScope = createRepetitionScopeMap(nextLevel);
+    const activeScope = createActiveScopeMap();
     let shouldShowRepetitionMessage = false;
 
     if (nextLevel === "strong" || nextLevel === "partial") {
       for (let instrumentIndex = 0; instrumentIndex < kitSize; instrumentIndex += 1) {
         for (let stepIndex = 0; stepIndex < loopLength; stepIndex += 1) {
-          if (!isStepAllowedByGridResolution(stepIndex)) continue;
+          if (!activeScope[instrumentIndex][stepIndex]) continue;
 
-          const wasActive = isEffectiveStepActiveForLevel(
+          const wasActive = isEffectiveStepActiveForLevel(instrumentIndex, stepIndex, previousLevel);
+          const willBeActive = getProjectedStepStateForRepetitionChange(
             instrumentIndex,
             stepIndex,
             previousLevel,
-            previousScope
-          );
-          const willBeActive = isEffectiveStepActiveForLevel(
-            instrumentIndex,
-            stepIndex,
             nextLevel,
-            nextScope
+            activeScope
           );
 
           if (wasActive !== willBeActive) {
@@ -658,34 +697,24 @@ document.addEventListener("DOMContentLoaded", () => {
 
     for (let instrumentIndex = 0; instrumentIndex < instruments.length; instrumentIndex += 1) {
       for (let stepIndex = 0; stepIndex < stepsPerInstrument; stepIndex += 1) {
-        const wasDerived =
-          previousScope[instrumentIndex][stepIndex] &&
-          getRepetitionSourceStepForLevel(stepIndex, previousLevel) !== null;
-        const isDerived =
-          nextScope[instrumentIndex][stepIndex] &&
-          getRepetitionSourceStepForLevel(stepIndex, nextLevel) !== null;
+        if (!activeScope[instrumentIndex][stepIndex]) continue;
+
+        const wasDerived = getRepetitionSourceStepForLevel(stepIndex, previousLevel) !== null;
+        const isDerived = getRepetitionSourceStepForLevel(stepIndex, nextLevel) !== null;
         if (!wasDerived || isDerived) continue;
 
-        pattern[instrumentIndex][stepIndex] = isEffectiveStepActiveForLevel(
-          instrumentIndex,
-          stepIndex,
-          previousLevel,
-          previousScope
-        );
+        pattern[instrumentIndex][stepIndex] = isEffectiveStepActiveForLevel(instrumentIndex, stepIndex, previousLevel);
       }
     }
 
     repetitionLevel = nextLevel;
-    applyRepetitionScope(nextScope);
     refreshStepAvailabilityState();
     savePatternToStorage();
     updateDensityState();
 
     if (!silent && shouldShowRepetitionMessage) {
       showTemporaryTryMessage(
-        nextLevel === "strong"
-          ? "Repetition applied: second half now mirrors the first."
-          : "Repetition applied: part of the second half now mirrors part of the first.",
+        getRepetitionAppliedMessage(nextLevel),
         4500
       );
     }
@@ -696,9 +725,11 @@ document.addEventListener("DOMContentLoaded", () => {
     return KIT_SIZE_OPTIONS[sliderIndex - 1];
   }
 
-  function updateKitSizeState() {
+  function updateKitSizeState(options = {}) {
+    const { silent = false } = options;
     const kitSlider = constraintSliders[KIT_SIZE_SLIDER_INDEX];
     if (!kitSlider) return;
+    const previousSnapshot = captureVisibleRepetitionOverrideSnapshot();
 
     kitSize = readKitSizeFromSliderValue(kitSlider.value);
 
@@ -715,6 +746,7 @@ document.addEventListener("DOMContentLoaded", () => {
     refreshStepAvailabilityState();
 
     updateDensityState();
+    maybeShowRepetitionScopeChangeMessage(previousSnapshot, silent);
   }
 
   function readDensityLevelFromSliderValue(sliderValue) {
@@ -1127,7 +1159,7 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
-  // Per-slider input handling: update labels, refresh loop/kit/grid/density state, and persist values.
+  // Per-slider input handling: update labels, refresh current constraint state, and persist values.
   loadConstraintValuesFromStorage();
 
   constraintSliders.forEach((slider, index) => {
@@ -1171,17 +1203,17 @@ document.addEventListener("DOMContentLoaded", () => {
         updateSliderLabel(index, slider.value);
       });
 
-      updateLoopLengthState();
-      updateGridResolutionState();
-      updateKitSizeState();
+      updateLoopLengthState({ silent: true });
+      updateGridResolutionState({ silent: true });
+      updateKitSizeState({ silent: true });
       updateRepetitionState({ silent: true });
       saveConstraintValuesToStorage();
     });
   }
 
-  updateLoopLengthState();
-  updateGridResolutionState();
-  updateKitSizeState();
+  updateLoopLengthState({ silent: true });
+  updateGridResolutionState({ silent: true });
+  updateKitSizeState({ silent: true });
   updateRepetitionState({ silent: true });
 });
 

--- a/style.css
+++ b/style.css
@@ -429,6 +429,17 @@ body {
   border-color: rgba(121, 183, 255, 0.4);
 }
 
+.step-cell--derived {
+  background: #24303d;
+  border-color: #4a6686;
+  cursor: not-allowed;
+}
+
+.step-cell--derived.step-cell--active {
+  background: rgba(91, 167, 255, 0.4);
+  border-color: rgba(141, 192, 255, 0.7);
+}
+
 .step-cell--over-limit-removable {
   box-shadow: inset 0 0 0 1px rgba(255, 184, 92, 0.55);
   border-color: rgba(255, 184, 92, 0.75);
@@ -436,6 +447,10 @@ body {
 
 .step-cell--blocked {
   animation: blocked-step-pulse 0.26s ease;
+}
+
+.step-cell--derived-feedback {
+  animation: derived-step-pulse 0.26s ease;
 }
 
 @keyframes blocked-step-pulse {
@@ -450,6 +465,18 @@ body {
   100% {
     box-shadow: inset 0 0 0 0 rgba(255, 138, 138, 0);
     border-color: #2f3744;
+  }
+}
+
+@keyframes derived-step-pulse {
+  0% {
+    box-shadow: inset 0 0 0 0 rgba(145, 192, 255, 0);
+  }
+  45% {
+    box-shadow: inset 0 0 0 1px rgba(145, 192, 255, 0.5);
+  }
+  100% {
+    box-shadow: inset 0 0 0 0 rgba(145, 192, 255, 0);
   }
 }
 


### PR DESCRIPTION
## Description

This PR introduces the **Repetition** constraint slider into ConstraintLab.

It adds a structural constraint that controls how patterns repeat within the active loop, allowing users to explore how repetition shapes rhythm creation.

**Included in this phase:**

- Implementation of the Repetition constraint slider  
  - Slider levels updated to **Strong / Partial / Free**  
  - Strong enforces full repetition of the second half of the loop  
  - Partial enforces repetition on part of the second half, leaving the end editable  
  - Free removes all repetition constraints  
- Enforcement of repetition editing rules  
  - Repeated cells are not independently editable  
  - Editing source cells updates repeated regions automatically  
- Integration with existing constraints  
  - Repetition applies only within the active Loop Length  
  - Respects Grid Resolution and Kit Size constraints  
  - Density counts the effective pattern including repeated steps  
- Handling of active scope updates  
  - Repetition dynamically re-applies when Loop Length, Kit Size, or Grid Resolution changes  
  - Newly active cells correctly reflect the current repetition rule  
- Addition of tooltips for Repetition  
  - Hovering over the label explains the constraint  
  - Each level describes its behavior in simple terms  
- Addition of lightweight feedback  
  - Displays a temporary message when repetition modifies the initial pattern  

No changes to other constraint logic or core playback behavior are introduced in this phase.

Closes #15 